### PR TITLE
fix: configure release-please for 0.0.1-alpha prerelease

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "98e8ae9ccca7b625103fcc1b63d9671491cf420d",
   "include-component-in-tag": false,
   "packages": {
     ".": {
@@ -9,7 +10,8 @@
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
       "prerelease": true,
-      "prerelease-type": "alpha"
+      "prerelease-type": "alpha",
+      "initial-version": "0.0.1-alpha.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `bootstrap-sha` to skip initial scaffold commit
- Set `initial-version` to `0.0.1-alpha.0`

Fixes release-please proposing v1.0.0 instead of pre-v1 alpha releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)