### PR TITLE
ci: remove push trigger, only run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, "release-please--**"]
   pull_request:
   workflow_call:
 


### PR DESCRIPTION
## Summary
- Remove `push` trigger from CI workflow — branch protection prevents direct pushes to main
- Fixes double CI runs on release-please PRs (push to branch + PR event)
- `workflow_call` retained for other workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)