### PR TITLE
feat: input data validation

### DIFF
--- a/src/tsam_xarray/_core.py
+++ b/src/tsam_xarray/_core.py
@@ -61,7 +61,7 @@ def aggregate(
     col_dims = _resolve_cluster_dim(cluster_dim)
     slice_dims = _infer_slice_dims(da, time_dim, col_dims)
     _validate(da, time_dim, col_dims, slice_dims)
-    _validate_data(da, time_dim, col_dims, slice_dims)
+    da = _validate_data(da, time_dim, col_dims, slice_dims)
     _validate_no_cluster_config_weights(tsam_kwargs)
     per_dim_weights = _normalize_weights(weights, da, col_dims)
 
@@ -151,8 +151,11 @@ def _validate_data(
     time_dim: str,
     col_dims: list[str],
     slice_dims: list[str],
-) -> None:
-    """Validate data values, dtypes, and coordinates."""
+) -> xr.DataArray:
+    """Validate data values, dtypes, and coordinates.
+
+    Returns the (possibly computed) DataArray.
+    """
     # Reserved dimension names
     all_user_dims = {time_dim, *col_dims, *slice_dims}
     reserved_conflict = all_user_dims & _RESERVED_DIMS
@@ -163,6 +166,16 @@ def _validate_data(
             "your input DataArray."
         )
         raise ValueError(msg)
+
+    # Dask arrays — compute before other checks
+    if hasattr(da.data, "dask"):
+        import warnings
+
+        warnings.warn(
+            "DataArray is backed by dask. Computing eagerly for tsam.",
+            stacklevel=3,
+        )
+        da = da.compute()
 
     # Numeric dtype
     if not np.issubdtype(da.dtype, np.number):
@@ -185,16 +198,6 @@ def _validate_data(
         msg = "DataArray contains NaN values. Clean your data before aggregating."
         raise ValueError(msg)
 
-    # Dask arrays
-    if hasattr(da.data, "dask"):
-        import warnings
-
-        warnings.warn(
-            "DataArray is backed by dask. Computing eagerly for tsam.",
-            stacklevel=3,
-        )
-        da = da.compute()
-
     # Regular time frequency
     time_vals = da.coords[time_dim].values
     if len(time_vals) > 1:
@@ -205,6 +208,8 @@ def _validate_data(
                 "Found irregular time intervals."
             )
             raise ValueError(msg)
+
+    return da
 
 
 def _to_dataframe(

--- a/test/test_aggregate.py
+++ b/test/test_aggregate.py
@@ -659,6 +659,39 @@ class TestDataValidation:
                 da, time_dim="time", cluster_dim="timestep", n_clusters=4
             )
 
+    def test_reserved_dim_name_period(self):
+        time = pd.date_range("2020-01-01", periods=30 * 24, freq="h")
+        da = xr.DataArray(
+            np.random.default_rng(42).random((len(time), 2, 2)),
+            dims=["time", "variable", "period"],
+            coords={
+                "time": time,
+                "variable": ["a", "b"],
+                "period": [0, 1],
+            },
+        )
+        with pytest.raises(ValueError, match="reserved"):
+            tsam_xarray.aggregate(
+                da,
+                time_dim="time",
+                cluster_dim="variable",
+                n_clusters=4,
+            )
+
+    def test_dask_array_warns(self):
+        pytest.importorskip("dask")
+        da = _make_da()
+        da_flat = da.isel(region=0).drop_vars("region")
+        da_dask = da_flat.chunk({"time": 100})
+        with pytest.warns(UserWarning, match="dask"):
+            result = tsam_xarray.aggregate(
+                da_dask,
+                time_dim="time",
+                cluster_dim="variable",
+                n_clusters=4,
+            )
+        assert not hasattr(result.typical_periods.data, "dask")
+
     def test_nan_rejected(self):
         da = _make_da()
         da_flat = da.isel(region=0).drop_vars("region")


### PR DESCRIPTION
## Summary

Validates input data before passing to tsam, catching common issues with clear error messages:

| Check | Error type | Message |
|-------|-----------|---------|
| Reserved dim names (`cluster`, `timestep`, `period`) | `ValueError` | "reserved by tsam_xarray" |
| NaN in data | `ValueError` | "contains NaN values" |
| Non-numeric dtype | `TypeError` | "must be numeric" |
| Non-datetime time coord | `TypeError` | "must have datetime coordinates" |
| Irregular time spacing | `ValueError` | "must have regular spacing" |
| Dask-backed arrays | `UserWarning` | warns and computes eagerly |

Closes #15

## Test plan
- [x] 45 tests passing (6 new validation tests)
- [x] mypy strict
- [x] ruff clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Strengthened input validation in `aggregate()` to detect invalid dimension names, non-numeric data types, non-datetime time coordinates, missing values, and irregularly-spaced timestamps.
  * Added warnings for dask-backed arrays with automatic computation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->