### PR TITLE
chore: set up Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         run: uv sync --group dev
 
       - name: Run tests
-        run: uv run pytest --cov --cov-report=xml --cov-report=term-missing
+        run: uv run pytest --cov=src/tsam_xarray --cov-report=xml --cov-report=term-missing
 
       - uses: codecov/codecov-action@v5
         if: matrix.python-version == '3.12'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/tsam-xarray)](https://pypi.org/project/tsam-xarray/)
 [![Python](https://img.shields.io/pypi/pyversions/tsam-xarray)](https://pypi.org/project/tsam-xarray/)
 [![CI](https://github.com/FBumann/tsam_xarray/actions/workflows/ci.yaml/badge.svg)](https://github.com/FBumann/tsam_xarray/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/FBumann/tsam_xarray/graph/badge.svg)](https://codecov.io/gh/FBumann/tsam_xarray)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-readthedocs-blue)](https://tsam_xarray.readthedocs.io/)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%


### PR DESCRIPTION
## Summary
- Add `codecov.yml` with project target (auto, 1% threshold) and patch target (80%)
- Update CI workflow to use explicit `--cov=src/tsam_xarray` flag
- Add Codecov badge to README

## Setup required
Add `CODECOV_TOKEN` as a repository secret (Settings → Secrets and variables → Actions).

## Test plan
- [ ] Verify CI passes and coverage report is uploaded
- [ ] Confirm Codecov badge renders on README after first upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)