### PR TITLE
docs: use notebook_connected renderer for smaller docs

### DIFF
--- a/docs/examples/clustering-io.ipynb
+++ b/docs/examples/clustering-io.ipynb
@@ -24,7 +24,7 @@
     "import tsam_xarray\n",
     "from tsam_xarray._sample_data import sample_energy_data\n",
     "\n",
-    "pio.renderers.default = \"notebook\"\n",
+    "pio.renderers.default = \"notebook_connected\"\n",
     "\n",
     "da = sample_energy_data(n_days=30).sel(region=\"north\", scenario=\"low\")\n",
     "print(f\"Shape: {dict(da.sizes)}\")"

--- a/docs/examples/getting-started.ipynb
+++ b/docs/examples/getting-started.ipynb
@@ -31,7 +31,7 @@
     "import tsam_xarray\n",
     "from tsam_xarray._sample_data import sample_energy_data\n",
     "\n",
-    "pio.renderers.default = \"notebook\"\n",
+    "pio.renderers.default = \"notebook_connected\"\n",
     "\n",
     "da = sample_energy_data(n_days=30)\n",
     "print(f\"Shape: {dict(da.sizes)}\")\n",

--- a/docs/examples/multi-dim.ipynb
+++ b/docs/examples/multi-dim.ipynb
@@ -26,7 +26,7 @@
     "import tsam_xarray\n",
     "from tsam_xarray._sample_data import sample_energy_data\n",
     "\n",
-    "pio.renderers.default = \"notebook\"\n",
+    "pio.renderers.default = \"notebook_connected\"\n",
     "\n",
     "da = sample_energy_data(n_days=30)\n",
     "print(f\"Dims: {list(da.dims)}\")\n",

--- a/docs/examples/segmentation.ipynb
+++ b/docs/examples/segmentation.ipynb
@@ -28,7 +28,7 @@
     "import tsam_xarray\n",
     "from tsam_xarray._sample_data import sample_energy_data\n",
     "\n",
-    "pio.renderers.default = \"notebook\"\n",
+    "pio.renderers.default = \"notebook_connected\"\n",
     "\n",
     "da = sample_energy_data(n_days=30).sel(region=\"north\", scenario=\"low\")\n",
     "print(f\"Input shape: {dict(da.sizes)}\")"


### PR DESCRIPTION
## Summary

Switch plotly renderer from `notebook` (embeds ~3MB plotly.js per page) to `notebook_connected` (CDN link, ~1KB per page).

Page sizes are significantly smaller while charts still render interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)