### PR TITLE
chore(ci): remove dead github-release job from publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,6 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
   id-token: write
   attestations: write
 
@@ -39,28 +38,3 @@ jobs:
         run: uv build
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-
-  github-release:
-    name: Create GitHub Release
-    needs: [publish]
-    if: github.event_name == 'push' && needs.publish.result == 'success'
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.ref_name }}
-
-      - name: Create GitHub Release
-        run: |
-          if gh release view "$TAG" &>/dev/null; then
-            echo "Release $TAG already exists, skipping."
-            exit 0
-          fi
-          if [[ "$TAG" == *-* ]]; then
-            gh release create "$TAG" --generate-notes --prerelease
-          else
-            gh release create "$TAG" --generate-notes
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

`release-please-action` already creates the GitHub release when the release PR merges — verified across the full release history:

| Tag | Release author | Body source |
|---|---|---|
| v0.4.0 | fluxopt-release[bot] | CHANGELOG section |
| v0.5.0 | fluxopt-release[bot] | CHANGELOG section |
| v0.5.1 | fluxopt-release[bot] | CHANGELOG section |
| v0.5.2 | fluxopt-release[bot] | CHANGELOG section |
| v0.6.0 | fluxopt-release[bot] | CHANGELOG section |

The `github-release` job in `publish.yaml` has been dead code — its `gh release view "$TAG" &>/dev/null && exit 0` branch was the one firing on every run, because the release already existed by the time the tag-push triggered publish.yaml.

This PR:
- Removes the `github-release` job from `publish.yaml`
- Drops `contents: write` from publish.yaml permissions (no longer needed; `id-token: write` and `attestations: write` remain for PyPI trusted publishing + sigstore attestations)

Net effect: zero behavioral change in production, less code to maintain, and the GitHub release body now matches the CHANGELOG (it always did — but now there's no redundant `--generate-notes` path that could diverge in the future).

## Test plan

- [ ] CI passes
- [ ] After merge, next release PR (whenever it appears) lands → release-please-action creates `vX.Y.Z` tag + GitHub release, publish.yaml fires on the tag push and pushes to PyPI

There's no way to dry-run this end-to-end without cutting an actual release, but the verification above covers the only behavior we're removing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Streamlined release automation workflow to focus on PyPI package distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FBumann/tsam_xarray/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->